### PR TITLE
Adding rustls-platform-verifier support for example code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rustls/symcrypt/.vscode/settings.json
 examples/target
 rustls-symcrypt/lcov.info
 rustls-symcrypt/.vscode/settings.json
+rustls-symcrypt/target

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +137,32 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "derive_more"
@@ -244,6 +282,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +356,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5831952a9476f2fed74b77d74182fa5ddc4d21c72ec45a333b250e3ed0272804"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -310,6 +403,12 @@ dependencies = [
  "normpath",
  "winapi",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_pipe"
@@ -435,6 +534,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +561,33 @@ name = "rustls-pki-types"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f0d26fa1ce3c790f9590868f0109289a044acb954525f933e2aa3b871c157d"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots",
+ "winapi",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
 
 [[package]]
 name = "rustls-symcrypt"
@@ -468,6 +607,7 @@ dependencies = [
  "once_cell",
  "rustls",
  "rustls-pemfile",
+ "rustls-platform-verifier",
  "rustls-symcrypt",
  "rustls-webpki",
  "webpki-roots",
@@ -507,6 +647,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "num-bigint",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -633,6 +806,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ webpki = {package = "rustls-webpki", version = "0.102", features = ["alloc"], de
 rustls-pemfile = "2.1.0"
 cmake = "0.1"
 once_cell = "1.8.0"
-
+rustls-platform-verifier = "0.3.1"
 
 [[bin]]
 name = "sample_internet_client"
@@ -28,3 +28,7 @@ path = "bin/sample_server.rs"
 [[bin]]
 name = "sample_local_client"
 path = "bin/sample_local_client.rs"
+
+[[bin]]
+name = "sample_internet_client_platform"
+path = "bin/sample_internet_client_platform.rs"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Rust TLS Examples
 
-This README provides an overview and usage instructions for three Rust programs that demonstrate the use of `rustls` and `rustls_symcrypt`. These examples include an internet client, a local client, and a local server.
+This README provides an overview and usage instructions for three Rust programs that demonstrate the use of `rustls` and `rustls_symcrypt`. These examples include an internet client, an internet client with platform certificate verification, a local client, and a local server.
 
 
 `sample_local_client` and `sample_server` both require certs and/or keys for proper functionality. These sample certs have been provided in the `bin/certs` path. 
@@ -12,7 +12,14 @@ This example establishes a TLS connection to `rust-lang.org` using `default_symc
 ### Usage
 `cargo run --bin sample_internet_client`
 
-## 2. Sample Local Client (`sample_local_client`)
+## 2. Sample Internet Client with Platform Verifier (`sample_internet_client_platform`)
+
+This example establishes a TLS connection to `rust-lang.org` using `default_symcrypt_provider()`. and [rustls-platform-verifier](https://github.com/rustls/rustls-platform-verifier). This program does not take in any certs or keys and instead relies the roots that are managed by your platform.
+
+### Usage
+`cargo run --bin sample_internet_client_client`
+
+## 3. Sample Local Client (`sample_local_client`)
 
 This example shows how to connect to a local server on `localhost:4444` using `custom_symcrypt_provider()`. This program requires the usage of a sample root ca which has been provided and is named `RootCA.pem`. To get the client to connect to connect, you can either start the `sample_server` in a separate terminal window, or you can start a simple openssl server in a separate terminal window.
 
@@ -23,7 +30,7 @@ To spin up a simple openssl server please use the following from the `bin/certs`
 ### Usage
 `cargo run --bin sample_local_client`.
 
-## 3. Sample Server (`sample_server`)
+## 4. Sample Server (`sample_server`)
 
 This example shows how to set up a server application that listens on `localhost:4444` for incoming TLS connections. This program requires the usage of an end cert and it's key which have been provided and is named `localhost.crt` and `localhost.pem` respectively. To get a client to connect to your server, you can either start `sample_local_client` in a separate terminal window, or you can start a simple openssl client in a separate terminal window.
 

--- a/examples/bin/sample_internet_client_platform.rs
+++ b/examples/bin/sample_internet_client_platform.rs
@@ -1,0 +1,53 @@
+use rustls_symcrypt::default_symcrypt_provider;
+use rustls_platform_verifier::Verifier;
+
+use std::io::{stdout, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+/// Usage
+/// This program provides a simple internet client using rustls-symcrypt to connect to rust-lang.org
+/// It uses rustls-platform-verifier to use your machines cert validation.
+/// To run this program you can use the following command in your terminal:
+/// cargo run --bin sample_internet_client_platform
+fn main() {
+    let config = rustls::ClientConfig::builder_with_provider(Arc::new(default_symcrypt_provider()))
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(Verifier::new().with_provider(Arc::new(default_symcrypt_provider()))))
+        .with_no_client_auth();
+
+    let server_name = "www.rust-lang.org".try_into().unwrap();
+    let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+
+    println!("Connecting to rust-lang.org, using the default_symcrypt_provider()");
+
+    tls.write_all(
+        concat!(
+            "GET / HTTP/1.1\r\n",
+            "Host: rust-lang.org\r\n",
+            "Connection: close\r\n",
+            "Accept-Encoding: identity\r\n",
+            "\r\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+
+    let ciphersuite = tls.conn.negotiated_cipher_suite().unwrap();
+    writeln!(
+        &mut std::io::stderr(),
+        "Current ciphersuite: {:?}",
+        ciphersuite.suite()
+    )
+    .unwrap();
+
+    let mut plaintext = Vec::new();
+    tls.read_to_end(&mut plaintext).unwrap();
+    stdout().write_all(&plaintext).unwrap();
+
+    println!("Connection established");
+}

--- a/rustls-symcrypt/src/lib.rs
+++ b/rustls-symcrypt/src/lib.rs
@@ -298,6 +298,7 @@ static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
+// TODO: Switch to symcrypt for verification
 static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
         webpki_algs::ECDSA_P256_SHA256,


### PR DESCRIPTION
Adding `rustls-platfom-verifier` support for the example code in `rustls-symcrypt`.

As of `rustls-platform-verifier` version `0.3.1` we are able to add support for a TLS connection with the custom `SymCrypt` provider as well as the Windows chain building code.

Changes:
- added support for `rustls-platform-verifier` in example code
- updated documentation 


